### PR TITLE
fix quiz answer path

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -17,23 +17,21 @@ class QuizzesController < ApplicationController
 
   def index
     @quizzes = Quiz.where(user_id: current_user.id).paginate(page: params[:page])
-    @quiz = Quiz.find_by(id: params[:id])
   end
 
   def index2
     @quizzes = Quiz.all.paginate(page: params[:page])
-    @quiz = Quiz.find_by(id: params[:id])
   end
-  
+
   def show
     @quiz = Quiz.find(params[:quiz_id])
   end
-  
+
   def new
     @quiz = Quiz.new
   end
 
-  
+
 
   def answer
     @quiz = Quiz.find(params[:quizzes_id])
@@ -50,7 +48,7 @@ end
   def user_params
     params.require(:user).permit(:final_answer)
   end
-      
+
  # ログイン済みユーザーかどうか確認
   def logged_in_user
     unless logged_in?

--- a/app/views/quizzes/_form2.html.erb
+++ b/app/views/quizzes/_form2.html.erb
@@ -1,14 +1,14 @@
-<%= @quiz.question %> 
+<%= @quiz.question %>
 
 <%= form_with url: {controller: 'quizzes', action: 'answer' } do  |f| %>
 
   <%= f.label :答えの入力 %>
-  <%= f.text_field :user.final_answer, class: 'form-control' %>
+  <%= f.text_field :final_answer, class: 'form-control' %>
 
   <%= f.submit yield(:button_text), class: "btn btn-primary" %>
 <% end %>
 
-<span class="user">名前 <%= link_to quizzes.user.name, quizzes.user %></span>
-  <span class="number_of_times_solved"> <%= quizzes.number_of_times_solved %></span>
-  <span class="number_of_correct_answers"> <%= quizzes.number_of_correct_answers %></span>
-  <span class="number_of_times_we_saw_the_answer"> <%= quizzes.number_of_times_we_saw_the_answer %></span>
+<span class="user">名前 <%= link_to @quiz.user.name, user_path(@quiz.user) %></span>
+  <span class="number_of_times_solved"> <%= @quiz.number_of_times_solved %></span>
+  <span class="number_of_correct_answers"> <%= @quiz.number_of_correct_answers %></span>
+  <span class="number_of_times_we_saw_the_answer"> <%= @quiz.number_of_times_we_saw_the_answer %></span>

--- a/app/views/quizzes/index.html.erb
+++ b/app/views/quizzes/index.html.erb
@@ -4,10 +4,11 @@
 <%= link_to "問題を見る", quizzes_index2_path %><br>
 <%= link_to "問題を作る", quizzes_new_path %><br>
 
-<%= will_paginate %>
 
 <ul class="quizzes">
-  <%= render @quizzes %>
+  <% @quizzes.each do |quiz| %>
+    <li><%= link_to quiz.question, quizzes_answer_path(quiz) %></li>
+  <% end %>
 </ul>
 
-<%= will_paginate %>
+<%= will_paginate @quizzes %>


### PR DESCRIPTION
>問題の出題と答えを入力するフォームをどうやっても表示することができません。
>クイズコントローラーにanswerアクションを作ったのですが、URLにIDを入力することができません。（URLがquizzes/ans>wer/quizzes_idと表示されてしまいます）どうしたらいいでしょうか？

PRを出しましたので内容がやりたいことと合っているか確認をお願いできればと思います。
内容は以下です。

・取得したクイズ群をループし、一つ一つにlink_toでリンクを仕込んでいる
・これにより、目的の `:quizzes_id` がパスに含まれた形でページ遷移できるようにしている
また、遷移後のページでエラーが出ていたので、エラー解消だけ行いました。
解答ボタン押下時の処理については、まだ触れていません。

ご確認宜しくお願い致します。