### PR TITLE
レイアウト全体修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -353,3 +353,16 @@ input[type="password"] {
     margin-inline: auto;
   }
 }
+
+.small-input {
+  max-width: 120px;
+}
+
+.d-flex {
+  display: flex;
+  gap: 8px;
+}
+
+.align-items-center {
+  align-items: center;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -6,9 +6,9 @@
 $gray-medium-light: #eaeaea;
 
 @mixin box_sizing {
-  -moz-box-sizing:    border-box;
+  -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
-  box-sizing:         border-box;
+  box-sizing: border-box;
 }
 
 /* universal */
@@ -34,7 +34,12 @@ textarea {
 
 /* typography */
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   line-height: 1;
 }
 
@@ -58,7 +63,6 @@ p {
   font-size: 1.1em;
   line-height: 1.7em;
 }
-
 
 /* header */
 
@@ -180,7 +184,10 @@ aside {
 
 /* forms */
 
-input, textarea, select, .uneditable-input {
+input,
+textarea,
+select,
+.uneditable-input {
   border: 1px solid #bbb;
   width: 100%;
   margin-bottom: 15px;
@@ -272,7 +279,8 @@ input[type="password"] {
       display: block;
       padding: 5px 0;
     }
-  }.bet_user_id {
+  }
+  .bet_user_id {
     display: block;
     margin-left: 60px;
     img {
@@ -321,13 +329,13 @@ input[type="password"] {
   padding: 16px 24px;
   margin: 16px 0px;
 }
- 
+
 .flash-message.notice {
   background-color: #bcdfff;
-  color: #0067C0;
-  border: solid 1px #0067C0;
+  color: #0067c0;
+  border: solid 1px #0067c0;
 }
- 
+
 .flash-message.alert {
   background-color: #ffd4d1;
   color: #930403;
@@ -365,4 +373,111 @@ input[type="password"] {
 
 .align-items-center {
   align-items: center;
+}
+
+.nav {
+  max-height: 100% !important;
+}
+
+.hamburger {
+  display: inline-block;
+  position: absolute;
+  right: 15px;
+  cursor: pointer;
+  padding: 24px 14px;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+
+  .navicon {
+    display: block;
+    height: 3px;
+    width: 26px;
+    position: absolute;
+    right: 0;
+    transition: 0.3192s cubic-bezier(0.04, 0.04, 0.12, 0.96) 0.1008s;
+    background: #fff;
+
+    &::before,
+    &::after {
+      content: "";
+      display: block;
+      height: 100%;
+      width: 100%;
+      position: absolute;
+      transition: 0.3192s cubic-bezier(0.04, 0.04, 0.12, 0.96);
+      background: #fff;
+    }
+
+    &::before {
+      top: 10px;
+    }
+
+    &::after {
+      top: -10px;
+    }
+  }
+
+  &.active {
+    .navicon {
+      background: transparent;
+
+      &::before {
+        top: 0;
+        transform: rotate(45deg);
+      }
+
+      &::after {
+        top: 0;
+        transform: rotate(-45deg);
+      }
+    }
+  }
+}
+
+.header_nav {
+  display: flex;
+  flex-direction: column;
+
+  li {
+    list-style: none;
+    padding: 10px 0;
+
+    a {
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+
+  .dropdown-menu {
+    a {
+      color: #000;
+    }
+  }
+}
+
+.navi {
+  width: fit-content;
+  transition: 0.5s;
+  opacity: 0;
+  transform: scale(0);
+  position: absolute;
+  top: 50px;
+  left: 0;
+  width: 100%;
+
+  &.active {
+    opacity: 1;
+    transform: scale(1);
+    background-color: #222;
+  }
+}
+
+.container {
+  position: relative;
+}
+
+.nav_inner {
+  max-width: 1170px;
+  margin: 0 auto;
+  padding: 0 15px;
+  position: relative;
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -184,6 +184,7 @@ input, textarea, select, .uneditable-input {
   border: 1px solid #bbb;
   width: 100%;
   margin-bottom: 15px;
+  padding: 8px;
   @include box_sizing;
 }
 
@@ -332,4 +333,24 @@ input[type="password"] {
   background-color: #ffd4d1;
   color: #930403;
   border: solid 1px #930403;
+}
+
+.search_form {
+  .flex {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+
+    @media (max-width: 768px) {
+      flex-direction: column;
+    }
+  }
+
+  // submit button
+  .submit {
+    max-width: 140px;
+    display: flex;
+    margin-inline: auto;
+  }
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -487,3 +487,32 @@ input[type="password"] {
   margin: 0 auto;
   padding: 30px 15px;
 }
+
+.wallper {
+  padding: 0 15px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.log_table {
+  width: 100%;
+
+  table {
+    width: 100%;
+
+    td,
+    th {
+      width: 25%;
+    }
+
+    th {
+      background-color: #f5f5f5;
+      padding: 10px;
+    }
+
+    td {
+      padding: 10px;
+      border: 1px solid #f5f5f5;
+    }
+  }
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -194,7 +194,6 @@ input, textarea, select, .uneditable-input {
 
 input[type="text"] {
   width: 100%;
-  height: 80px;
 }
 
 input[type="password"] {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -481,3 +481,9 @@ input[type="password"] {
   padding: 0 15px;
   position: relative;
 }
+
+.form_inner {
+  max-width: 555px;
+  margin: 0 auto;
+  padding: 30px 15px;
+}

--- a/app/javascript/custom/menu.js
+++ b/app/javascript/custom/menu.js
@@ -5,8 +5,9 @@ document.addEventListener("turbo:load", function() {
   let hamburger = document.querySelector("#hamburger");
   hamburger.addEventListener("click", function(event) {
     event.preventDefault();
+    hamburger.classList.toggle("active");
     let menu = document.querySelector("#navbar-menu");
-    menu.classList.toggle("collapse");
+    menu.classList.toggle("active");
   });
   let account = document.querySelector("#account");
   account.addEventListener("click", function(event) {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,51 +1,42 @@
 <header class="navbar navbar-fixed-top navbar-inverse">
-  <div class="container">
+  <div class="nav_inner">
     <%= link_to "psycho-logic", root_path, id: "logo" %>
-    <nav>
-      <div class="navbar-header">
-        <button id="hamburger" type="button" class="navbar-toggle collapsed">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
-      </div>
-      <ul id="navbar-menu"
-          class="nav navbar-nav navbar-right collapse navbar-collapse">
-          <ul class="nav navbar-nav navbar-right">
-        <li><%= link_to "Home", root_path %></li>
-        <li><%= link_to "Help", help_path %></li>
-        <% if logged_in? %>
-          <li><%= link_to "Users", users_path %></li>
-          <li><%= link_to "dice_ranking", users_ranking_path %></li>
-          <li><%= link_to "タスク", tasks_index_path %></li>
-          <li><%= link_to "クイズ", quizzes_path %></li>
-          <li><%= link_to "小説の感想", novels_path %></li>
-          <li><%= link_to "ミニノウハウ", mini_know_hows_path %></li>
-          <li><%= link_to "お気に入り", favorites_path %></li>
-          <li><%= link_to "メール", point_mails_path %></li>
-
-
-
-          
-          <li class="dropdown">
-            <a href="#" id="account" class="dropdown-toggle">
-              Account <b class="caret"></b>
-            </a>
-            <ul id="dropdown-menu" class="dropdown-menu">
-              <li><%= link_to "Profile", current_user %></li>
-              <li><%= link_to "Settings", edit_user_path(current_user) %></li>
-              <li class="divider"></li>
-              <li>
-                <%= link_to "Log out", logout_path,
-                                       data: { "turbo-method": :delete } %>
-              </li>
-            </ul>
-          </li>
-        <% else %>
-          <li><%= link_to "Log in", login_path %></li>
-        <% end %>
-      </ul>
-    </nav>
+    <div class="navbar-header">
+      <label id="hamburger" type="button" class="hamburger">
+        <span class="navicon"></span>
+      </label>
+    </div>
   </div>
+  <nav id="navbar-menu" class="navi">
+    <ul class="header_nav">
+      <li><%= link_to "Home", root_path %></li>
+      <li><%= link_to "Help", help_path %></li>
+      <% if logged_in? %>
+      <li><%= link_to "Users", users_path %></li>
+      <li><%= link_to "dice_ranking", users_ranking_path %></li>
+      <li><%= link_to "タスク", tasks_index_path %></li>
+      <li><%= link_to "クイズ", quizzes_path %></li>
+      <li><%= link_to "小説の感想", novels_path %></li>
+      <li><%= link_to "ミニノウハウ", mini_know_hows_path %></li>
+      <li><%= link_to "お気に入り", favorites_path %></li>
+      <li><%= link_to "メール", point_mails_path %></li>
+      <li class="dropdown">
+        <a href="#" id="account" class="dropdown-toggle">
+          Account <b class="caret"></b>
+        </a>
+        <ul id="dropdown-menu" class="dropdown-menu">
+          <li><%= link_to "Profile", current_user %></li>
+          <li><%= link_to "Settings", edit_user_path(current_user) %></li>
+          <li class="divider"></li>
+          <li>
+            <%= link_to "Log out", logout_path,
+                                       data: { "turbo-method": :delete } %>
+          </li>
+        </ul>
+      </li>
+      <% else %>
+      <li><%= link_to "Log in", login_path %></li>
+      <% end %>
+    </ul>
+  </nav>
 </header>

--- a/app/views/mini_know_hows/_form.html.erb
+++ b/app/views/mini_know_hows/_form.html.erb
@@ -1,10 +1,10 @@
 <%= form_with url: {controller: 'mini_know_hows', action: 'create' } do  |f| %>
 
   <%= f.label :タイトル %>
-  <%= f.text_field :title, class: 'form-control' %>
+  <%= f.text_area :title, class: 'form-control', rows: 3 %>
 
   <%= f.label :本文 %>
-  <%= f.text_field :content, class: 'form-control' %>
+  <%= f.text_area :content, class: 'form-control', rows: 20 %>
 
   <%= f.label :設定したい閲覧料 %>
   <%= f.number_field :viewing_fee, class: 'form-control' %>

--- a/app/views/mini_know_hows/search.html.erb
+++ b/app/views/mini_know_hows/search.html.erb
@@ -1,7 +1,9 @@
 <div class="id search_form">
-    <%= form_with url: mini_know_hows_search_result_path, local: true, method: :get do |f| %>
-      <%= f.number_field :id_number %>
-      <%= f.select :range, options_for_select([["ミニノウハウのIDを入力する","mini_know_how_id"], ["ミニノウハウの制作者IDを検索する","user_id"]]) %>
-      <%= f.submit "検索", class: "btn btn-primary" %>
-    <% end %>
+  <%= form_with url: mini_know_hows_search_result_path, local: true, method: :get do |f| %>
+  <div class="form_inner">
+    <%= f.number_field :id_number %>
+    <%= f.select :range, options_for_select([["ミニノウハウのIDを入力する","mini_know_how_id"], ["ミニノウハウの制作者IDを検索する","user_id"]]) %>
+    <%= f.submit "検索", class: "btn btn-primary" %>
   </div>
+  <% end %>
+</div>

--- a/app/views/novels/_form.html.erb
+++ b/app/views/novels/_form.html.erb
@@ -1,10 +1,9 @@
-<%= form_with url: {controller: 'novels', action: 'create' } do  |f| %>
-  
+<%= form_with url: {controller: 'novels', action: 'create' } do |f| %>
   <%= f.label :小説タイトル %>
-  <%= f.text_field :work_name, class: 'form-control' %>
+  <%= f.text_area :work_name, class: 'form-control', rows: 3 %>
 
   <%= f.label :あらすじ %>
-  <%= f.text_field :synopsis, class: 'form-control' %>
+  <%= f.text_area :synopsis, class: 'form-control', rows: 15 %>
 
   <%= f.label :URL1 %>
   <%= f.text_field :url1, class: 'form-control' %>
@@ -16,8 +15,10 @@
   <%= f.text_field :url3, class: 'form-control' %>
 
   <%= f.label :status %>
-  <%= f.number_field :status, class: 'form-control' %>
-  <%= "個の感想が欲しい。" %>
+  <div class="d-flex align-items-center">
+    <%= f.number_field :status, class: 'form-control small-input' %>
+    <span>この感想が欲しい</span>
+  </div>
 
   <%= f.submit yield(:button_text), class: "btn btn-primary" %>
 <% end %>

--- a/app/views/novels/_form2.html.erb
+++ b/app/views/novels/_form2.html.erb
@@ -1,10 +1,10 @@
 <%= form_with url: {controller: 'novels', action: 'update' } do  |f| %>
   
   <%= f.label :小説タイトル %>
-  <%= f.text_field :work_name, class: 'form-control' %>
+  <%= f.text_area :work_name, class: 'form-control', rows: 3 %>
 
   <%= f.label :あらすじ %>
-  <%= f.text_field :synopsis, class: 'form-control' %>
+  <%= f.text_area :synopsis, class: 'form-control', rows: 15 %>
 
   <%= f.label :URL1 %>
   <%= f.text_field :url1, class: 'form-control' %>

--- a/app/views/novels/search.html.erb
+++ b/app/views/novels/search.html.erb
@@ -1,9 +1,11 @@
 <div class="id search_form">
-    <%= form_with url: novels_search_result_path, local: true, method: :get do |f| %>
-      <div class="flex">
-        <%= f.number_field :id_number %>
-        <%= f.select :range, options_for_select([["小説のIDを入力する","novel_id"], ["小説の制作者IDを検索する","user_id"]]) %>
-      </div>
-      <%= f.submit "検索", class: "btn btn-primary" %>
-    <% end %>
+  <%= form_with url: novels_search_result_path, local: true, method: :get do |f| %>
+  <div class="form_inner">
+    <div class="flex">
+      <%= f.number_field :id_number %>
+      <%= f.select :range, options_for_select([["小説のIDを入力する","novel_id"], ["小説の制作者IDを検索する","user_id"]]) %>
+    </div>
+    <%= f.submit "検索", class: "btn btn-primary" %>
   </div>
+  <% end %>
+</div>

--- a/app/views/novels/search.html.erb
+++ b/app/views/novels/search.html.erb
@@ -1,7 +1,9 @@
 <div class="id search_form">
     <%= form_with url: novels_search_result_path, local: true, method: :get do |f| %>
-      <%= f.number_field :id_number %>
-      <%= f.select :range, options_for_select([["小説のIDを入力する","novel_id"], ["小説の制作者IDを検索する","user_id"]]) %>
+      <div class="flex">
+        <%= f.number_field :id_number %>
+        <%= f.select :range, options_for_select([["小説のIDを入力する","novel_id"], ["小説の制作者IDを検索する","user_id"]]) %>
+      </div>
       <%= f.submit "検索", class: "btn btn-primary" %>
     <% end %>
   </div>

--- a/app/views/point_logs/show.html.erb
+++ b/app/views/point_logs/show.html.erb
@@ -1,6 +1,6 @@
 <% provide(:title,  @user.name) %>
 <div class="row">
-  <aside class="col-md-4">
+  <aside class="wallper">
     <section class="user_info">
       <h1>
         <%= gravatar_for @user %>
@@ -12,14 +12,43 @@
         <% else %>
         <%= @user.dice_point_expiry_date.strftime('%Y年%m月%d日') %><br><br>
         <% end %>
-        <% @point_logs.each do |point_logs| %>
-          <%= point_logs.service_name %>
-          <%= point_logs.category %>
-          <%= point_logs.dice_point %>
-          <%= point_logs.created_at.strftime('%Y/%m/%d %H:%M:%S') %><br>
-        <% end %>
+      </h1>
 
-              </h1>
+      <!-- ポイントログのテーブル表示 -->
+      <div class="log_table">
+        <table>
+          <thead>
+            <tr>
+              <th>サービス</th>
+              <th>内容</th>
+              <th>ポイント</th>
+              <th>時間</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @point_logs.each do |log| %>
+            <tr>
+              <td><%= log.service_name %></td>
+              <td><%= log.category %></td>
+              <td><%= log.dice_point %></td>
+              <td><%= log.created_at.strftime('%Y/%m/%d %H:%M:%S') %></td>
+            </tr>
+            <% end %>
+            <tr>
+              <td>サービスA</td>
+              <td>ポイント獲得</td>
+              <td>100</td>
+              <td>2024/10/12 05:32:17</td>
+            </tr>
+            <tr>
+              <td>サービスB</td>
+              <td>購入によるポイント</td>
+              <td>200</td>
+              <td>2024/10/12 06:15:10</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </section>
   </aside>
 </div>

--- a/app/views/point_mails/_form.html.erb
+++ b/app/views/point_mails/_form.html.erb
@@ -7,10 +7,10 @@
   <%= f.email_field :send_user_email, class: 'form-control' %>
 
   <%= f.label :タイトル %>
-  <%= f.text_field :title, class: 'form-control' %>
+  <%= f.text_area :title, class: 'form-control', rows: 2 %>
 
   <%= f.label :メールの本文 %>
-  <%= f.text_field :content, class: 'form-control' %>
+  <%= f.text_area :content, class: 'form-control', rows: 15 %>
 
   <%= f.label :送るダイスポイント %>
   <%= f.number_field :send_dice_point, class: 'form-control' %>

--- a/app/views/quizzes/_form.html.erb
+++ b/app/views/quizzes/_form.html.erb
@@ -1,7 +1,6 @@
 <%= form_with url: {controller: 'quizzes', action: 'create' } do  |f| %>
-  
   <%= f.label :問題 %>
-  <%= f.text_field :question, class: 'form-control' %>
+  <%= f.text_area :question, class: 'form-control', rows: 10 %>
 
   <%= f.label :答えの入力 %>
   <%= f.text_field :answer, class: 'form-control' %>

--- a/app/views/quizzes/_form_edit.html.erb
+++ b/app/views/quizzes/_form_edit.html.erb
@@ -1,6 +1,6 @@
 <%= form_with(model: @quiz, url: quiz_path(@quiz, quizzes_id: @quiz.id), method: :patch) do |f| %>
   <%= f.label :問題 %>
-  <%= f.text_field :question, class: 'form-control' %>
+  <%= f.text_area :question, class: 'form-control', rows: 10 %>
 
   <%= f.label :答えの入力 %>
   <%= f.text_field :answer, class: 'form-control' %>

--- a/app/views/quizzes/search.html.erb
+++ b/app/views/quizzes/search.html.erb
@@ -1,7 +1,11 @@
 <div class="id search_form">
-    <%= form_with url: quizzes_search_result_path, local: true, method: :get do |f| %>
+  <%= form_with url: quizzes_search_result_path, local: true, method: :get do |f| %>
+  <div class="form_inner">
+    <div class="flex">
       <%= f.number_field :id_number %>
       <%= f.select :range, options_for_select([["クイズのIDを入力する","quiz_id"], ["クイズの制作者IDを検索する","user_id"]]) %>
-      <%= f.submit "検索", class: "btn btn-primary" %>
-    <% end %>
+    </div>
+    <%= f.submit "検索", class: "btn btn-primary" %>
   </div>
+  <% end %>
+</div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,16 +1,15 @@
 <%= form_with url: {controller: 'tasks', action: 'create' } do  |f| %>
-  
-  <%= f.label :内容 %>
-  <%= f.text_field :content, class: 'form-control' %>
+    <%= f.label :内容 %>
+    <%= f.text_area :content, class: 'form-control', rows: 5 %>
 
-  <%= f.label :あげるかもしれないユーザーのID %>
-  <%= f.number_field :bet_user_id, class: 'form-control' %>
+    <%= f.label :あげるかもしれないユーザーのID %>
+    <%= f.number_field :bet_user_id, class: 'form-control' %>
 
-  <%= f.label :タスクの締め切り %>
-  <%= f.datetime_field :deadline_at, class: 'form-control' %>
+    <%= f.label :タスクの締め切り %>
+    <%= f.datetime_field :deadline_at, class: 'form-control' %>
 
-  <%= f.label :かけるダイス数 %>
-  <%= f.number_field :amount_bet, class: 'form-control',value: '2000' %>
+    <%= f.label :かけるダイス数 %>
+    <%= f.number_field :amount_bet, class: 'form-control',value: '2000' %>
 
-  <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+    <%= f.submit yield(:button_text), class: "btn btn-primary" %>
 <% end %>

--- a/app/views/tasks/search.html.erb
+++ b/app/views/tasks/search.html.erb
@@ -1,9 +1,11 @@
 <div class="id search_form">
   <%= form_with url: tasks_search_result_path, local: true, method: :get do |f| %>
+  <div class="form_inner">
     <div class="flex">
       <%= f.number_field :id_number %>
       <%= f.select :range, options_for_select([["タスクのIDを入力する","task_id"], ["タスクの制作者IDを検索する","user_id"]]) %>
     </div>
     <%= f.submit "検索", class: "btn btn-primary" %>
+  </div>
   <% end %>
 </div>

--- a/app/views/tasks/search.html.erb
+++ b/app/views/tasks/search.html.erb
@@ -1,7 +1,9 @@
 <div class="id search_form">
-    <%= form_with url: tasks_search_result_path, local: true, method: :get do |f| %>
+  <%= form_with url: tasks_search_result_path, local: true, method: :get do |f| %>
+    <div class="flex">
       <%= f.number_field :id_number %>
       <%= f.select :range, options_for_select([["タスクのIDを入力する","task_id"], ["タスクの制作者IDを検索する","user_id"]]) %>
-      <%= f.submit "検索", class: "btn btn-primary" %>
-    <% end %>
-  </div>
+    </div>
+    <%= f.submit "検索", class: "btn btn-primary" %>
+  <% end %>
+</div>


### PR DESCRIPTION
## 概要
- 全体的にレイアウトを修正して扱いやすくする。

## 対応内容
- [タスクページ](https://psycho-logic.jp/tasks/new)
  - 内容を複数行入力できるようにする（デフォルトで5行分表示）
- [タスク検索ページ](https://psycho-logic.jp/tasks/search)
  - 入力コンテンツを横並びにする
  - 検索ボタンの横幅を小さくして中央に配置
- [問題ページ](https://psycho-logic.jp/quizzes/new)
  - 問題を複数行入力できるようにする（デフォルトで10行分表示）
  - 答えの入力を1行分の高さで表示
    - 実際にはinput[type="text"]の高さ指定していたcssを外した
- [小説の感想ページ ](https://psycho-logic.jp/novels/new)
  - 小説のタイトル
    - 3行くらいのスペース
  - あらすじ
    - 複数行対応。15行
  - Url1 URL2 URL3
    - 1行
  - Status
    - 1行で4分の１の長さにして、隣に「この感想が欲しい」を表示。
- [ポイント付メール](https://psycho-logic.jp/point_mails)
  - タイトル
    - 複数行対応。2行表示
  - 本文
    - 複数行対応。15行表示
- [ミニノウハウ ](https://psycho-logic.jp/mini_know_hows/new)
  - タイトル
    - 複数行対応。3行表示
  - 本文
    - 複数行対応20行表示
- [ID検索ページ](https://psycho-logic.jp/mini_know_hows/search)
  - 計3ページほど？の横幅調整
  - 入力コンテンツを横並びに
  - submitボタンの横幅短くして中央に表示する
- ユーザーページ
  - データをtableで表示 