### PR TITLE
レイアウト修正対応

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -437,44 +437,27 @@ input[type="password"] {
   transition: 0.5s;
   opacity: 0;
   position: absolute;
-  top: 0;
-  left: 55%;
-  transform: scale(0) translateX(-50%);
+  top: 50px;
+  left: 0;
+  transform: scale(0) translateX(0);
+  background-color: #333;
   width: 100%;
-  height: 50px;
-
-  // 998px以下の場合
-  @media (max-width: 998px) {
-    top: 50px;
-    left: 0;
-    transform: scale(0) translateX(0);
-    background-color: #333;
-    opacity: 1;
-    height: auto;
-  }
+  opacity: 1;
+  height: auto;
 
   &.active {
     opacity: 1;
-    transform: scale(1) translateX(-50%);
+    transform: scale(1) translateX(0);
     background-color: #222;
-
-    // 998px以下の場合
-    @media (max-width: 998px) {
-      transform: scale(1) translateX(0);
-    }
   }
 
   .header_nav {
     display: flex;
     justify-content: center;
     align-items: center;
+    flex-direction: column;
     gap: 12px;
     padding: 4px;
-
-    // 998px以下の場合
-    @media (max-width: 998px) {
-      flex-direction: column;
-    }
 
     li {
       list-style: none;

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -12,19 +12,11 @@
       <li><%= link_to "ミニノウハウ", mini_know_hows_path %></li>
       <li><%= link_to "お気に入り", favorites_path %></li>
       <li><%= link_to "メール", point_mails_path %></li>
-      <li class="dropdown">
-        <a href="#" id="account" class="dropdown-toggle">
-          Account <b class="caret"></b>
-        </a>
-        <ul id="dropdown-menu" class="dropdown-menu">
-          <li><%= link_to "Profile", current_user %></li>
-          <li><%= link_to "Settings", edit_user_path(current_user) %></li>
-          <li class="divider"></li>
-          <li>
-            <%= link_to "Log out", logout_path,
+      <li><%= link_to "Profile", current_user %></li>
+      <li><%= link_to "Settings", edit_user_path(current_user) %></li>
+      <li>
+        <%= link_to "Log out", logout_path,
                                        data: { "turbo-method": :delete } %>
-          </li>
-        </ul>
       </li>
       <% else %>
       <li><%= link_to "Log in", login_path %></li>

--- a/app/views/novels/_form.html.erb
+++ b/app/views/novels/_form.html.erb
@@ -17,7 +17,7 @@
   <%= f.label :status %>
   <div class="d-flex align-items-center">
     <%= f.number_field :status, class: 'form-control small-input' %>
-    <span>この感想が欲しい</span>
+    <span>個の感想が欲しい</span>
   </div>
 
   <%= f.submit yield(:button_text), class: "btn btn-primary" %>

--- a/app/views/novels_supports/_form.html.erb
+++ b/app/views/novels_supports/_form.html.erb
@@ -2,7 +2,7 @@
   <%= f.hidden_field :novel_id, value: @novel.id %>
 
   <%= f.label :コメント %>
-  <%= f.text_field :comment, class: 'form-control' %>
+  <%= f.text_area :comment, class: 'form-control', rows: 10 %>
 
   <%= f.label :応援するダイスポイント数 %>
   <%= f.number_field :support_fee, class: 'form-control',value: '1000' %>

--- a/app/views/point_logs/show.html.erb
+++ b/app/views/point_logs/show.html.erb
@@ -34,18 +34,6 @@
               <td><%= log.created_at.strftime('%Y/%m/%d %H:%M:%S') %></td>
             </tr>
             <% end %>
-            <tr>
-              <td>サービスA</td>
-              <td>ポイント獲得</td>
-              <td>100</td>
-              <td>2024/10/12 05:32:17</td>
-            </tr>
-            <tr>
-              <td>サービスB</td>
-              <td>購入によるポイント</td>
-              <td>200</td>
-              <td>2024/10/12 06:15:10</td>
-            </tr>
           </tbody>
         </table>
       </div>

--- a/app/views/thoughts/_form.html.erb
+++ b/app/views/thoughts/_form.html.erb
@@ -5,7 +5,7 @@
   <%= f.hidden_field :novel_id, value: novel.id %>
 
   <%= f.label :感想 %>
-  <%= f.text_field :thoughts, class: 'form-control' %>
+  <%= f.text_area :thoughts, class: 'form-control', rows: 10 %>
 
   <%= f.submit yield(:button_text), class: "btn btn-primary" %>
 <% end %>

--- a/app/views/thoughts/_form_thoughts.html.erb
+++ b/app/views/thoughts/_form_thoughts.html.erb
@@ -3,7 +3,7 @@
   <%= f.hidden_field :thought_id, value: thought.id %>
 
   <%= f.label :感想 %>
-  <%= f.text_field :thoughts, class: 'form-control' %>
+  <%= f.text_area :thoughts, class: 'form-control', rows: 10 %>
 
   <%= f.submit yield(:button_text), class: "btn btn-primary" %>
 <% end %>

--- a/app/views/users/_form2.html.erb
+++ b/app/views/users/_form2.html.erb
@@ -1,20 +1,20 @@
 <%= form_with(model: @user) do |f| %>
-  <%= render 'shared/error_messages', object: @user %>
+<%= render 'shared/error_messages', object: @user %>
 
-  <%= f.label :名前%>
-  <%= f.text_field :name, class: 'form-control' %>
+<%= f.label :名前%>
+<%= f.text_field :name, class: 'form-control' %>
 
-  <%= f.label :メールアドレス %>
-  <%= f.email_field :email, class: 'form-control' %>
+<%= f.label :メールアドレス %>
+<%= f.email_field :email, class: 'form-control' %>
 
-  <%= f.label :パスワード %>
-  <%= f.password_field :password, class: 'form-control' %>
+<%= f.label :パスワード %>
+<%= f.password_field :password, class: 'form-control' %>
 
-  <%= f.label :パスワードの確認 %>
-  <%= f.password_field :password_confirmation, class: 'form-control' %>
+<%= f.label :パスワードの確認 %>
+<%= f.password_field :password_confirmation, class: 'form-control' %>
 
-   <%= f.label :簡単なプロフィール %>
-  <%= f.text_field :profile, class: 'form-control' %>
+<%= f.label :簡単なプロフィール %>
+<%= f.text_area :profile, class: 'form-control', rows: 5 %>
 
-  <%= f.submit yield(:button_text), class: "btn btn-primary" %>
+<%= f.submit yield(:button_text), class: "btn btn-primary" %>
 <% end %>


### PR DESCRIPTION
## 概要
- 10/19にオンラインミーティングで話し合った内容にそって修正対応を行う。

## 内容
- ヘッダー
  - PCの見た目をスマホ版に合わせる
  - Accountの内容をドロップダウンをやめてそのまま表示
- 小説
  - この感想 → 個の感想
- ユーザー設定
  -  簡単なプロフィールを改行可能にして5行表示に変更
- 応援系
  - 改行可能に 