### PR TITLE
ハンバーガーメニュー修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -382,7 +382,7 @@ input[type="password"] {
 .hamburger {
   display: inline-block;
   position: absolute;
-  right: 15px;
+  right: 16px;
   cursor: pointer;
   padding: 24px 14px;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -438,17 +438,23 @@ input[type="password"] {
   opacity: 0;
   position: absolute;
   top: 50px;
-  left: 0;
-  transform: scale(0) translateX(0);
+  right: 16px;
   background-color: #333;
   width: 100%;
-  opacity: 1;
+  max-width: 240px;
+  opacity: 0;
   height: auto;
+  pointer-events: none;
+
+  // 768px以下の時
+  @media (max-width: 768px) {
+    right: 4px;
+  }
 
   &.active {
     opacity: 1;
-    transform: scale(1) translateX(0);
     background-color: #222;
+    pointer-events: auto;
   }
 
   .header_nav {
@@ -457,11 +463,12 @@ input[type="password"] {
     align-items: center;
     flex-direction: column;
     gap: 12px;
-    padding: 4px;
+    padding: 12px 4px;
+    margin-bottom: 0;
 
     li {
       list-style: none;
-      padding: 10px 0;
+      padding: 4px 0;
 
       a {
         color: #fff;
@@ -485,7 +492,6 @@ input[type="password"] {
   max-width: 1170px;
   margin: 0 auto;
   padding: 0 15px;
-  position: relative;
 }
 
 .form_inner {

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,6 +81,8 @@ Rails.application.configure do
     'X-Frame-Options' => "ALLOW-FROM #{pf_domain}"
   }
 
+  config.assets.debug = true
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 


### PR DESCRIPTION
## 概要
- ハンバーガーメニューを要望に応じて修正する。

## 内容
- ハンバーガーメニューのボタンの位置を画面の右端に移動
- ハンバーガーメニューの横幅のサイズを縮小
- ハンバーガーメニューを右端に表示

## レイアウト
- 修正後の見た目
![スクリーンショット 2024-10-21 午後22 02 49 午後](https://github.com/user-attachments/assets/8947dcd6-a279-4c3f-854b-6f13bb0dd9a3)
![スクリーンショット 2024-10-21 午後22 02 41 午後](https://github.com/user-attachments/assets/6ac949ef-dd51-49eb-ad6d-986b23b60bf4)
